### PR TITLE
Change baseTitle to titleSuffix

### DIFF
--- a/Sources/Site.swift
+++ b/Sources/Site.swift
@@ -16,7 +16,7 @@ struct IgniteWebsite {
 
 struct ExampleSite: Site {    
     var name = "Hello World"
-    var baseTitle = " – My Awesome Site"
+    var titleSuffix = " – My Awesome Site"
     var url = URL("https://www.example.com")
     var builtInIconsEnabled = true
 


### PR DESCRIPTION
The page title suffix never seemed to work for me, so went digging in the framework source. Couldn't find any mention of `baseTitle` in the `Site` protocol definition, but `titleSuffix` seems to be the correct string and gives the expected functionality.